### PR TITLE
Fixed issue with discovery and connection to AlarmDecoder

### DIFF
--- a/service_manager.groovy
+++ b/service_manager.groovy
@@ -340,9 +340,8 @@ def addExistingDevices() {
                 state.hub = newDevice.value.hub
 
                 // Set URN for the child device
-                def urn = newDevice.value.ssdpPath
-                urn -= "http://"
-                state.urn = urn
+                state.urn = convertHexToIP(state.ip) + ":" + convertHexToInt(state.port)
+                log.trace("AlarmDecoder webapp api endpoint('${state.urn}')")
 
                 // Create device and subscribe to it's zone-on/off events.
                 d = addChildDevice("alarmdecoder", "AlarmDecoder Network Appliance", "${state.ip}:${state.port}", newDevice?.value.hub, [name: "${state.ip}:${state.port}", label: "AlarmDecoder", completedSetup: true, data:[urn: state.urn]])


### PR DESCRIPTION
the URN for the AlarmDecoder stopped working. I have change it to use the IP and PORT of the discovered device stored in HEX() to build the URN as "IP:PORT" this will later be used by hub_http_get to communicate with the AlarmDecoder rest API.