### PR TITLE
Rfx zones

### DIFF
--- a/devicetypes/alarmdecoder/alarmdecoder-virtual-carbon-monoxide-detector.src/alarmdecoder-virtual-carbon-monoxide-detector.groovy
+++ b/devicetypes/alarmdecoder/alarmdecoder-virtual-carbon-monoxide-detector.src/alarmdecoder-virtual-carbon-monoxide-detector.groovy
@@ -28,6 +28,8 @@ metadata {
     namespace: APPNAMESPACE,
     author: "Nu Tech Software Solutions, Inc.") {
     capability "CarbonMonoxideDetector"
+	attribute "low_battery", "bool"
+	attribute "last_checkin", "number"
   }
 
   // tile definitions
@@ -67,6 +69,11 @@ metadata {
       title: "Zone Number",
       description: "Zone # required for zone events.",
       required: false)
+    input(
+      name: "serial", type:
+      "string", title: "Serial Number",
+      description: "The serial number of an RF device.",
+      required: false)
   }
 }
 
@@ -82,9 +89,11 @@ metadata {
 def installed() {
   updateDataValue("invert", invert.toString())
   updateDataValue("zone", zone.toString())
+  updateDataValue("serial", serial)
 }
 
 def updated() {
   updateDataValue("invert", invert.toString())
   updateDataValue("zone", zone.toString())
+  updateDataValue("serial", serial)
 }

--- a/devicetypes/alarmdecoder/alarmdecoder-virtual-contact-sensor.src/alarmdecoder-virtual-contact-sensor.groovy
+++ b/devicetypes/alarmdecoder/alarmdecoder-virtual-contact-sensor.src/alarmdecoder-virtual-contact-sensor.groovy
@@ -28,6 +28,8 @@ metadata {
     namespace: APPNAMESPACE,
     author: "Nu Tech Software Solutions, Inc.") {
     capability "Contact Sensor"
+	attribute "low_battery", "bool"
+	attribute "last_checkin", "number"
   }
 
   // tile definitions
@@ -66,6 +68,11 @@ metadata {
       "number", title: "Zone Number",
       description: "Zone # required for zone events.",
       required: false)
+    input(
+      name: "serial", type:
+      "string", title: "Serial Number",
+      description: "The serial number of an RF device.",
+      required: false)
   }
 }
 
@@ -81,9 +88,11 @@ metadata {
 def installed() {
   updateDataValue("invert", invert.toString())
   updateDataValue("zone", zone.toString())
+  updateDataValue("serial", serial)
 }
 
 def updated() {
   updateDataValue("invert", invert.toString())
   updateDataValue("zone", zone.toString())
+  updateDataValue("serial", serial)
 }

--- a/devicetypes/alarmdecoder/alarmdecoder-virtual-motion-detector.src/alarmdecoder-virtual-motion-detector.groovy
+++ b/devicetypes/alarmdecoder/alarmdecoder-virtual-motion-detector.src/alarmdecoder-virtual-motion-detector.groovy
@@ -28,6 +28,8 @@ metadata {
     namespace: APPNAMESPACE,
     author: "Nu Tech Software Solutions, Inc.") {
     capability "Motion Sensor"
+	attribute "low_battery", "bool"
+	attribute "last_checkin", "number"
   }
 
   // tile definitions
@@ -69,6 +71,11 @@ metadata {
       title: "Zone Number",
       description: "Zone # required for zone events.",
       required: false)
+    input(
+      name: "serial", type:
+      "string", title: "Serial Number",
+      description: "The serial number of an RF device.",
+      required: false)
   }
 }
 
@@ -84,11 +91,13 @@ metadata {
 def installed() {
   updateDataValue("invert", invert.toString())
   updateDataValue("zone", zone.toString())
+  updateDataValue("serial", serial)
 }
 
 def updated() {
   updateDataValue("invert", invert.toString())
   updateDataValue("zone", zone.toString())
+  updateDataValue("serial", serial)
 }
 
 // FIXME: what?

--- a/devicetypes/alarmdecoder/alarmdecoder-virtual-shock-sensor.src/alarmdecoder-virtual-shock-sensor.groovy
+++ b/devicetypes/alarmdecoder/alarmdecoder-virtual-shock-sensor.src/alarmdecoder-virtual-shock-sensor.groovy
@@ -28,6 +28,8 @@ metadata {
     namespace: APPNAMESPACE,
     author: "Nu Tech Software Solutions, Inc.") {
     capability "ShockSensor"
+	attribute "low_battery", "bool"
+	attribute "last_checkin", "number"
   }
 
   // tile definitions
@@ -68,6 +70,11 @@ metadata {
       title: "Zone Number",
       description: "Zone # required for zone events.",
       required: false)
+    input(
+      name: "serial", type:
+      "string", title: "Serial Number",
+      description: "The serial number of an RF device.",
+      required: false)
   }
 }
 
@@ -83,9 +90,11 @@ metadata {
 def installed() {
   updateDataValue("invert", invert.toString())
   updateDataValue("zone", zone.toString())
+  updateDataValue("serial", serial)
 }
 
 def updated() {
   updateDataValue("invert", invert.toString())
   updateDataValue("zone", zone.toString())
+  updateDataValue("serial", serial)
 }

--- a/devicetypes/alarmdecoder/alarmdecoder-virtual-smoke-alarm.src/alarmdecoder-virtual-smoke-alarm.groovy
+++ b/devicetypes/alarmdecoder/alarmdecoder-virtual-smoke-alarm.src/alarmdecoder-virtual-smoke-alarm.groovy
@@ -28,6 +28,8 @@ metadata {
     namespace: APPNAMESPACE,
     author: "Nu Tech Software Solutions, Inc.") {
     capability "Smoke Detector"
+	attribute "low_battery", "bool"
+	attribute "last_checkin", "number"
   }
 
   // tile definitions
@@ -67,6 +69,11 @@ metadata {
       title: "Zone Number",
       description: "Zone # required for zone events.",
       required: false)
+    input(
+      name: "serial", type:
+      "string", title: "Serial Number",
+      description: "The serial number of an RF device.",
+      required: false)
   }
 }
 
@@ -82,9 +89,11 @@ metadata {
 def installed() {
   updateDataValue("invert", invert.toString())
   updateDataValue("zone", zone.toString())
+  updateDataValue("serial", serial)
 }
 
 def updated() {
   updateDataValue("invert", invert.toString())
   updateDataValue("zone", zone.toString())
+  updateDataValue("serial", serial)
 }

--- a/smartapps/alarmdecoder/alarmdecoder-service.src/alarmdecoder-service.groovy
+++ b/smartapps/alarmdecoder/alarmdecoder-service.src/alarmdecoder-service.groovy
@@ -2023,6 +2023,41 @@ def rfxSet(evt) {
         sent = true
 
       } else {
+		  def d = getChildDevices().findAll {
+			it.deviceNetworkId.contains(":switch") &&
+			  it.getDataValue("serial") == sn
+		  }
+		  
+		  if (d) {
+			if (loop1 == "1" || loop2 == "1" || loop3 == "1" || loop4 == "1") {
+				d.each {
+				  _sendEventTranslate(it, ("on"), false)
+				}
+			}
+			else {
+				d.each {
+				  _sendEventTranslate(it, ("off"), false)
+				}
+				
+				d.each {
+					it.sendEvent(
+					  name: "low_battery",
+					  value: bat == "1"
+					)
+				}
+				
+				if (supv == "1") {
+					def last_checkin = now()
+					d.each {
+						it.sendEvent(
+						  name: "last_checkin",
+						  value: last_checkin
+						)
+					}
+				}
+			}
+			 
+		  } 
         if (debug) log.info("rfxSet device: ${device_name} no match ${match}")
       }
     }
@@ -2092,7 +2127,7 @@ def zoneOn(evt) {
   // Find all :switch devices with a matching zone the event.
   def d = getChildDevices().findAll {
     it.deviceNetworkId.contains(":switch") &&
-      it.getDataValue("zone") == evt.value
+      it.getDataValue("zone") == evt.value && it.getDataValue("serial") == null
   }
 
   if (d) {
@@ -2114,7 +2149,7 @@ def zoneOff(evt) {
 
   def d = getChildDevices().findAll {
     it.deviceNetworkId.contains(":switch") &&
-      it.getDataValue("zone") == evt.value
+      it.getDataValue("zone") == evt.value && it.getDataValue("serial") == null
   }
 
   if (d) {
@@ -3039,7 +3074,7 @@ private getDeviceNamePart(d) {
  *   Default clear = off, detected(Alerting) = on
  *
  */
-def _sendEventTranslate(ad2d, state) {
+def _sendEventTranslate(ad2d, state, stateChange = true) {
 
   // Grab the devices preferences for inverting
   def invert = (ad2d.device.getDataValue("invert") == "true" ? true : false)
@@ -3057,7 +3092,7 @@ def _sendEventTranslate(ad2d, state) {
     ad2d.sendEvent(
       name: "switch",
       value: (sval ? "on" : "off"),
-      isStateChange: true,
+      isStateChange: stateChange,
       filtered: true
     )
   }
@@ -3075,7 +3110,7 @@ def _sendEventTranslate(ad2d, state) {
     ad2d.sendEvent(
       name: "contact",
       value: (sval ? "open" : "closed"),
-      isStateChange: true,
+      isStateChange: stateChange,
       filtered: true
     )
   }
@@ -3093,7 +3128,7 @@ def _sendEventTranslate(ad2d, state) {
     ad2d.sendEvent(
       name: "motion",
       value: (sval ? "active" : "inactive"),
-      isStateChange: true,
+      isStateChange: stateChange,
       filtered: true
     )
   }
@@ -3111,7 +3146,7 @@ def _sendEventTranslate(ad2d, state) {
     ad2d.sendEvent(
       name: "shock",
       value: (sval ? "detected" : "clear"),
-      isStateChange: true,
+      isStateChange: stateChange,
       filtered: true
     )
   }
@@ -3129,7 +3164,7 @@ def _sendEventTranslate(ad2d, state) {
     ad2d.sendEvent(
       name: "carbonMonoxide",
       value: (sval ? "detected" : "clear"),
-      isStateChange: true,
+      isStateChange: stateChange,
       filtered: true
     )
   }
@@ -3147,7 +3182,7 @@ def _sendEventTranslate(ad2d, state) {
     ad2d.sendEvent(
       name: "smoke",
       value: (sval ? "detected" : "clear"),
-      isStateChange: true,
+      isStateChange: stateChange,
       filtered: true
     )
   }

--- a/smartapps/alarmdecoder/alarmdecoder-service.src/alarmdecoder-service.groovy
+++ b/smartapps/alarmdecoder/alarmdecoder-service.src/alarmdecoder-service.groovy
@@ -1986,6 +1986,43 @@ def rfxSet(evt) {
   def device_name = "RFX-${sn}-${bat}-${supv}-" +
     "${loop0}-${loop1}-${loop2}-${loop3}"
 
+    def d = getChildDevices().findAll {
+			it.deviceNetworkId.contains(":switch") &&
+			  it.getDataValue("serial") == sn
+		  }
+		  
+		  if (d) {
+			if (loop1 == "1" || loop2 == "1" || loop3 == "1" || loop4 == "1") {
+				d.each {
+				  _sendEventTranslate(it, ("on"), false)
+				}
+			}
+			else {
+				d.each {
+				  _sendEventTranslate(it, ("off"), false)
+				}
+				
+				d.each {
+					it.sendEvent(
+					  name: "low_battery",
+					  value: bat == "1"
+					)
+				}
+				
+				if (supv == "1") {
+					def last_checkin = now()
+					d.each {
+						it.sendEvent(
+						  name: "last_checkin",
+						  value: last_checkin
+						)
+					}
+				}
+			}
+			 
+		  } 
+
+    
   def children = getChildDevices()
   children.each {
     if (it.deviceNetworkId.contains(":RFX-")) {
@@ -2022,46 +2059,10 @@ def rfxSet(evt) {
 
         sent = true
 
-      } else {
-		  def d = getChildDevices().findAll {
-			it.deviceNetworkId.contains(":switch") &&
-			  it.getDataValue("serial") == sn
-		  }
-		  
-		  if (d) {
-			if (loop1 == "1" || loop2 == "1" || loop3 == "1" || loop4 == "1") {
-				d.each {
-				  _sendEventTranslate(it, ("on"), false)
-				}
-			}
-			else {
-				d.each {
-				  _sendEventTranslate(it, ("off"), false)
-				}
-				
-				d.each {
-					it.sendEvent(
-					  name: "low_battery",
-					  value: bat == "1"
-					)
-				}
-				
-				if (supv == "1") {
-					def last_checkin = now()
-					d.each {
-						it.sendEvent(
-						  name: "last_checkin",
-						  value: last_checkin
-						)
-					}
-				}
-			}
-			 
-		  } 
-        if (debug) log.info("rfxSet device: ${device_name} no match ${match}")
-      }
+      } 
     }
-  }
+      
+  }    
 
   if (!sent) {
     log.warn("rfxSet: Could not find '${device_name}|XXX' device.")

--- a/smartapps/alarmdecoder/alarmdecoder-service.src/alarmdecoder-service.groovy
+++ b/smartapps/alarmdecoder/alarmdecoder-service.src/alarmdecoder-service.groovy
@@ -1986,42 +1986,40 @@ def rfxSet(evt) {
   def device_name = "RFX-${sn}-${bat}-${supv}-" +
     "${loop0}-${loop1}-${loop2}-${loop3}"
 
-    def d = getChildDevices().findAll {
-			it.deviceNetworkId.contains(":switch") &&
-			  it.getDataValue("serial") == sn
-		  }
-		  
-		  if (d) {
-			if (loop1 == "1" || loop2 == "1" || loop3 == "1" || loop4 == "1") {
-				d.each {
-				  _sendEventTranslate(it, ("on"), false)
-				}
-			}
-			else {
-				d.each {
-				  _sendEventTranslate(it, ("off"), false)
-				}
-				
-				d.each {
-					it.sendEvent(
-					  name: "low_battery",
-					  value: bat == "1"
-					)
-				}
-				
-				if (supv == "1") {
-					def last_checkin = now()
-					d.each {
-						it.sendEvent(
-						  name: "last_checkin",
-						  value: last_checkin
-						)
-					}
-				}
-			}
-			 
-		  } 
-
+  def d = getChildDevices().findAll {
+    it.deviceNetworkId.contains(":switch") &&
+      it.getDataValue("serial") == sn
+  }
+      
+  if (d) {
+    if (loop1 == "1" || loop2 == "1" || loop3 == "1" || loop4 == "1") {
+        d.each {
+          _sendEventTranslate(it, ("on"), false)
+        }
+    }
+    else {
+      d.each {
+        _sendEventTranslate(it, ("off"), false)
+      }
+	}
+        
+    d.each {
+      it.sendEvent(
+        name: "low_battery",
+        value: bat == "1"
+      )
+    }
+        
+    if (supv == "1") {
+      def last_checkin = now()
+      d.each {
+        it.sendEvent(
+          name: "last_checkin",
+          value: last_checkin
+        )
+      }
+    }
+  } 
     
   def children = getChildDevices()
   children.each {
@@ -2061,7 +2059,6 @@ def rfxSet(evt) {
 
       } 
     }
-      
   }    
 
   if (!sent) {

--- a/smartapps/alarmdecoder/alarmdecoder-service.src/alarmdecoder-service.groovy
+++ b/smartapps/alarmdecoder/alarmdecoder-service.src/alarmdecoder-service.groovy
@@ -1992,7 +1992,7 @@ def rfxSet(evt) {
   }
       
   if (d) {
-    if (loop1 == "1" || loop2 == "1" || loop3 == "1" || loop4 == "1") {
+    if (loop0 == "1" || loop1 == "1" || loop2 == "1" || loop3 == "1") {
         d.each {
           _sendEventTranslate(it, ("on"), false)
         }


### PR DESCRIPTION
I found the process of creating RFX devices a bit cumbersome. I left what you had built but I also added another way of doing things. Basically I copied your idea of setting a zone in each device, you can now also set the RF serial #. If that serial # is set, it uses the RFX messages to trigger zone faults/restore instead of the zone tracker. I also added custom attributes for the low_battery message and to keep track of the last time a supervisor checkin was received. This just seems like a much easier way to configure it to me. Let me know what you think.